### PR TITLE
Implementation of a persistent shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@commander-js/extra-typings": "^11.0.0",
-        "@types/node": "^20.5.9",
+        "@types/node": "^20.6.0",
         "typescript": "^5.2.2"
       }
     },
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -1047,9 +1047,9 @@
       }
     },
     "@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "@types/wrap-ansi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@commander-js/extra-typings": "^11.0.0",
-    "@types/node": "^20.5.9",
+    "@types/node": "^20.6.0",
     "typescript": "^5.2.2"
   }
 }

--- a/src/commands/do.ts
+++ b/src/commands/do.ts
@@ -6,7 +6,7 @@ import {
   getRelevantExecutables,
   shellCommandFromToolCall,
 } from "../llm";
-import { runCommand } from "../runCommand";
+import { PersistentShell } from "../runCommand";
 import {
   logAssistant,
   logCommand,
@@ -32,6 +32,7 @@ export const doCommand = new Command("do")
   )
   .option("--path", "Get a list of executables available on PATH")
   .action(async (instruction, opts) => {
+    const shell = new PersistentShell();
     const messages: ChatMessage[] = [];
 
     if (!instruction) {
@@ -59,7 +60,7 @@ export const doCommand = new Command("do")
       console.log("Getting environment information...");
       const GET_PATH_EXECUTABLES_COMMAND =
         "echo $PATH | tr ':' '\n' | xargs -I {} ls {} 2>/dev/null | sort -u | tr '\n' ','";
-      const pathExecutables = await runCommand({
+      const pathExecutables = await shell.executeCommand({
         command: GET_PATH_EXECUTABLES_COMMAND,
         args: [],
         explanation: "Retrieving all executables in your PATH",
@@ -143,7 +144,7 @@ export const doCommand = new Command("do")
         const shellCommand = shellCommandFromToolCall(toolCall);
         logCommand(`${shellCommand.command} ${shellCommand.args.join(" ")}`);
         logExplanation(shellCommand.explanation);
-        const shellCommandOutput = await runCommand(shellCommand);
+        const shellCommandOutput = await shell.executeCommand(shellCommand);
         logCommandOutput(shellCommandOutput);
         const toolResponse =
           chatMessageFromShellCommandOutput(shellCommandOutput);

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -1,8 +1,9 @@
 import { ShellCommandOutput } from "./llm";
-import { runCommand } from "./runCommand";
+import { PersistentShell } from "./runCommand";
 
 const runCtagCommand = (): Promise<ShellCommandOutput> => {
-  return runCommand({
+  const shell = new PersistentShell();
+  return shell.executeCommand({
     command: "ctags --fields=+S --output-format=json -R .",
     args: [],
     explanation: "Generate ctags for the current project",

--- a/src/runCommand.ts
+++ b/src/runCommand.ts
@@ -1,29 +1,97 @@
-import { spawn } from "child_process";
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { ShellCommand, ShellCommandOutput } from "./llm";
+import { randomString } from "./utils/rand";
 
-export async function runCommand(
-  cmd: ShellCommand
-): Promise<ShellCommandOutput> {
-  return new Promise((resolve, reject) => {
-    const command = spawn(`${cmd.command} ${cmd.args.join(" ")}`, {
-      shell: true,
+export class PersistentShell {
+  process: ChildProcessWithoutNullStreams;
+  stdout: string;
+  stderr: string;
+  listeners: Map<string, () => void>;
+
+  constructor(shell?: string) {
+    this.process = this.createShellProcess(shell);
+    this.stdout = "";
+    this.stderr = "";
+    this.listeners = new Map();
+
+    this.process.stdout.on("data", (data) => {
+      data = data.toString();
+      this.stdout += data;
+      this.listeners.forEach((listener) => listener());
+    });
+    this.process.stderr.on("data", (data) => {
+      data = data.toString();
+      this.stderr += data;
+      this.listeners.forEach((listener) => listener());
     });
 
-    const commandOutput: ShellCommandOutput = {
-      stdout: "",
-      stderr: "",
-      exitCode: null,
-    };
+    this.process.on("exit", (exitCode) => {
+      console.log(`shell exit code ${exitCode}`);
+    });
 
-    command.stdout.on("data", (output) => {
-      commandOutput.stdout += output.toString();
+    this.process.on("error", (err) => {
+      console.error(`shell error: ${err}`);
     });
-    command.stderr.on("data", (output) => {
-      commandOutput.stderr += output.toString();
+    this.process.on("message", (msg) => {
+      console.error(`shell message: ${msg}`);
     });
-    command.on("close", (code) => {
-      commandOutput.exitCode = code;
-      resolve(commandOutput);
+    this.process.on("disconnect", () => {
+      console.log("shell disconnected");
     });
-  });
+  }
+
+  createShellProcess(shell?: string) {
+    let shellFile = "/bin/sh";
+    if (process.platform === "win32") {
+      shellFile = process.env.comspec || "cmd.exe";
+    } else if (process.platform === "android") {
+      shellFile = "/system/bin/sh";
+    }
+
+    shellFile = shell || shellFile;
+
+    return spawn(shellFile, {
+      shell: false,
+    });
+  }
+
+  executeCommand(cmd: ShellCommand): Promise<ShellCommandOutput> {
+    const uniqueCommandId = `end_command_${randomString(16)}`;
+
+    return new Promise((resolve, reject) => {
+      // This listener runs on every chunk received to either stdout or stderr
+      const onChunk = () => {
+        // Check the entire stdout for the unique end command id
+        if (this.stdout.includes(uniqueCommandId)) {
+          const splitStdout = this.stdout.split("\n");
+          while (splitStdout.pop() !== uniqueCommandId) {}
+          const exitCode = parseInt(splitStdout.pop() || "0");
+          const commandStdout = splitStdout.join("\n");
+
+          // Remove the end command id from the stdout
+          this.stdout = this.stdout.replace(uniqueCommandId, "");
+
+          // Remove the listener for this command
+          if (!this.listeners.delete(uniqueCommandId)) {
+            throw new Error(
+              `removing listener for command ${uniqueCommandId} failed`
+            );
+          }
+
+          resolve({
+            stdout: commandStdout,
+            stderr: this.stderr,
+            exitCode,
+          });
+        }
+      };
+      this.listeners.set(uniqueCommandId, onChunk);
+
+      // Write the main command, and the exit code retrieval, and the unique end command id
+      // to stdin on the shell.
+      this.process.stdin.write(`${cmd.command} ${cmd.args.join(" ")}\n`);
+      this.process.stdin.write(`echo $?\n`);
+      this.process.stdin.write(`echo ${uniqueCommandId}\n`);
+    });
+  }
 }

--- a/src/utils/rand.ts
+++ b/src/utils/rand.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export function randomString(length: number) {
+  return crypto.randomBytes(length).toString("hex").slice(0, length);
+}


### PR DESCRIPTION
This turned out to be harder to do than I thought and the solution here feels a tad hacky, but overall not too bad.

Because we want to run the commands in a persistent shell, and shells are for humans to write prompts in, it's actually not super easy to know when the last executed command has finished. We create a shell process by spawing `sh` and then all the 'real' commands are done by writing to stdin and reading from stdout/stderr (just like if you're using a terminal to work with a shell). In a tty, you get a prompt printed when the last command has finished executing, but this doesn't happen when running `sh` not in a tty (such as spawing a child process from node.js).

To work around it, we create a unique id for each command, and then `echo` that id to stdout after the main command. We can listen on stdout and receive the real command's output, and when we see that unique id (which should never accidentally appear in the real output), we know to stop reading and return everything else to the caller. 

In addition to this, we use `echo $?` to retrieve the exit code of the main command. There's a bit of string manipulation to get all the relevant output back out of the stdout stream. 

<img width="1267" alt="image" src="https://github.com/humanloop/asap/assets/37074155/120e576a-f4cc-47cf-b440-39616ef6c28e">
